### PR TITLE
Fundamental error in Xqxdecode

### DIFF
--- a/xqxdecode.c
+++ b/xqxdecode.c
@@ -142,6 +142,27 @@ proff(int curOff)
 	printf("%6x:	", curOff);
 }
 
+char*
+fgetsn(char* str, int n, FILE* stream)
+{
+  register int c;
+  register char ch;
+  register char* cs;
+  cs = str;
+
+  while (--n > 0 && (c = getc(stream)) != EOF) {
+    ch = (*cs++ = c);
+    if (ch == '\n') {
+      *cs = '\0';
+      break;
+    }
+    else if (ch == '\0')
+      break;
+  }
+
+  return (c == EOF && cs == str) ? NULL : str;
+}
+
 void
 decode(FILE *fp)
 {
@@ -178,7 +199,7 @@ decode(FILE *fp)
     {
 	char	buf[1024];
 
-	while (fgets(buf, sizeof(buf), fp))
+	while (fgetsn(buf, sizeof(buf), fp))
 	{
 	    proff(curOff);
 	    if (buf[0] == '\033')


### PR DESCRIPTION
Xqxdecode has a fundamental flaw that means it never actually ran properly. It uses `fgets()` to read the header lines, under the assumption that they are newline-terminated. However, the most important of them all, the one preceding the ',XQX' magic number is actually null-terminated, so the program never ever correctly identifies the magic number and gets completely lost in the file. By creating our own `fgetsn()` that looks for both newline and null makes it work.

The lines from the driver actually writing the null-terminated string are:

https://github.com/koenkooi/foo2zjs/blob/e04290de6b7a30d588f3411fd9834618e09f7b9b/foo2xqx.c#L630-L633